### PR TITLE
Header filter 필요없는 routing 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,12 @@ spring:
   cloud:
     gateway:
       routes:
+        - id: no-auth-user
+          uri: ${user-service.url}
+          predicates:
+            - Path=/api/v1/account/sign-up, /api/v1/account/sign-in, /api/v1/account/refresh, /api/v1/account/check-email/**,
+            - Path=/api/v1/account/email-auth-verify, /api/v1/account/email-auth-create, /api/v1/account/check-nickname/**,
+
         - id: user-service-account
           uri: ${user-service.url}
           predicates:


### PR DESCRIPTION
Header filter 가 필요없는 곳의 routing 을 추가했습니다.
현재 token refresh 를 하려고 해도 기존의 filter 에 token expired 가 나는 오류를 잡기 위함입니다.